### PR TITLE
Fix UB when T contains uninit bytes and when T is zero-sized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,15 +217,13 @@ impl<T> Stowaway<T> {
             }
             SizeClass::Boxed => Box::into_raw(Box::new(value)),
             SizeClass::Packed => {
-                // If T smaller than *mut T, we need to initialize the extra
-                // bytes. TODO: figure out a way to initialize these bytes (to
+                // T may contain uninit bytes, either by being smaller than
+                // the systems pointer width, or by containing fields which
+                // do not align.
+                // TODO: figure out a way to initialize these bytes (to
                 // the satisfaction of defined behavior) without zeroing them,
                 // if possible.
-                let mut blob: MaybeUninit<*mut T> = if size_of::<T>() < size_of::<*mut T>() {
-                    MaybeUninit::zeroed()
-                } else {
-                    MaybeUninit::uninit()
-                };
+                let mut blob: MaybeUninit<*mut T> = MaybeUninit::zeroed();
 
                 let ptr = blob.as_mut_ptr();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@ impl<T> Stowaway<T> {
         let storage = match Self::size_class() {
             SizeClass::Zero => {
                 mem::forget(value);
+                // Ptr must be correctly aligned, even for zero-sized types.
                 mem::align_of::<T>() as *mut T
             }
             SizeClass::Boxed => Box::into_raw(Box::new(value)),
@@ -277,7 +278,8 @@ impl<T> Stowaway<T> {
         mem::forget(stowed);
 
         match Self::size_class() {
-            // Safety: ptr::read is guaranteed to be a no-op for a ZST
+            // Safety: storage was created with correct alignment, as required
+            // even for zero-sized types.
             SizeClass::Zero => unsafe { ptr::read(storage) },
             // Safety: we previously created a box in `new`
             SizeClass::Boxed => *unsafe { Box::from_raw(storage) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,8 @@ impl<T> Drop for Stowaway<T> {
     fn drop(&mut self) {
         match Self::size_class() {
             // Safety: this value was previously owned by Self::new, and
-            // ptr::read on a zero-size type is a no-op
+            // storage was craeted with correct alignment as required by
+            // ptr::read even on zero-sized types.
             SizeClass::Zero => drop(unsafe { ptr::read(self.storage) }),
             // Safety: this box was previously created by Self::new
             SizeClass::Boxed => drop(unsafe { Box::from_raw(self.storage) }),
@@ -536,7 +537,8 @@ impl<T> AsRef<T> for Stowaway<T> {
     #[inline]
     fn as_ref(&self) -> &T {
         let ptr_to_storage = match Self::size_class() {
-            // In the ZST case, ptr::read is a no-op, so the null ptr here is fine
+            // Safety: Storage was created with correct alignment and
+            // therefore is also non-null.
             SizeClass::Zero => self.storage,
             // In the box case, storage IS a valid pointer, so simply
             // dereference it
@@ -552,7 +554,8 @@ impl<T> AsMut<T> for Stowaway<T> {
     #[inline]
     fn as_mut(&mut self) -> &mut T {
         let ptr_to_storage = match Self::size_class() {
-            // In the ZST case, ptr::read is a no-op, so the null ptr here is fine
+            // Safety: Storage was created with correct alignment and
+            // therefore is also non-null.
             SizeClass::Zero => self.storage,
             // In the box case, storage IS a valid pointer, so simply
             // dereference it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::fmt;
-use core::mem::{self, size_of, MaybeUninit};
+use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
 
@@ -213,7 +213,7 @@ impl<T> Stowaway<T> {
         let storage = match Self::size_class() {
             SizeClass::Zero => {
                 mem::forget(value);
-                ptr::null_mut()
+                mem::align_of::<T>() as *mut T
             }
             SizeClass::Boxed => Box::into_raw(Box::new(value)),
             SizeClass::Packed => {


### PR DESCRIPTION
Fixes #3 by always zero'ing the storage.