### PR TITLE
Fix UB when T contains uninit bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,12 +345,9 @@ mod test_for_uninit_bytes {
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         struct Gaps32 {
             a: u8,
-            b: u16
+            b: u16,
         }
-        let x = Gaps32 {
-            a: 7,
-            b: 42
-        };
+        let x = Gaps32 { a: 7, b: 42 };
         let stowed = stow(x);
         let unstowed = unsafe { unstow(stowed) };
         assert_eq!(x, unstowed);
@@ -360,12 +357,9 @@ mod test_for_uninit_bytes {
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         struct Gaps64 {
             a: u8,
-            b: u32
+            b: u32,
         }
-        let x = Gaps64 {
-            a: 7,
-            b: 42
-        };
+        let x = Gaps64 { a: 7, b: 42 };
         let stowed = stow(x);
         let unstowed = unsafe { unstow(stowed) };
         assert_eq!(x, unstowed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,8 @@ impl<T> Stowaway<T> {
             }
             SizeClass::Boxed => Box::into_raw(Box::new(value)),
             SizeClass::Packed => {
-                // If T smaller than *mut T, or contains uninit bytes inernally,
-                // we need to initialize the extra bytes. TODO: figure out a way
+                // Need to init (zero) all bytes. Even if sizeof(T) == sizeof(*T),
+                // T may contain unused/uninit padding bytes. TODO: figure out a way
                 // to initialize these bytes (to the satisfaction of defined
                 // behavior) without zeroing them, if possible.
                 let mut blob: MaybeUninit<*mut T> = MaybeUninit::zeroed();
@@ -316,7 +316,8 @@ impl<T> Stowaway<T> {
         storage as *mut ()
     }
 }
-// These tests should fail miri test
+// These tests are designed to detect undefined behavior in miri under naive,
+// incorrect implementations of Stowaway.
 #[cfg(test)]
 mod test_for_uninit_bytes {
     use crate::{stow, unstow};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,15 +217,11 @@ impl<T> Stowaway<T> {
             }
             SizeClass::Boxed => Box::into_raw(Box::new(value)),
             SizeClass::Packed => {
-                // If T smaller than *mut T, we need to initialize the extra
-                // bytes. TODO: figure out a way to initialize these bytes (to
-                // the satisfaction of defined behavior) without zeroing them,
-                // if possible.
-                let mut blob: MaybeUninit<*mut T> = if size_of::<T>() < size_of::<*mut T>() {
-                    MaybeUninit::zeroed()
-                } else {
-                    MaybeUninit::uninit()
-                };
+                // If T smaller than *mut T, or contains uninit bytes inernally,
+                // we need to initialize the extra bytes. TODO: figure out a way
+                // to initialize these bytes (to the satisfaction of defined
+                // behavior) without zeroing them, if possible.
+                let mut blob: MaybeUninit<*mut T> = MaybeUninit::zeroed();
 
                 let ptr = blob.as_mut_ptr();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,57 @@ impl<T> Stowaway<T> {
         storage as *mut ()
     }
 }
+// These tests should fail miri test
+#[cfg(test)]
+mod test_for_uninit_bytes {
+    use crate::{stow, unstow};
+    #[test]
+    fn zst() {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        struct Zst;
+        let x = Zst;
+        let stowed = stow(x);
+        let unstowed = unsafe { unstow(stowed) };
+        assert_eq!(x, unstowed);
+    }
+    #[test]
+    fn small_t() {
+        let x: u8 = 7;
+        let stowed = stow(x);
+        let unstowed = unsafe { unstow(stowed) };
+        assert_eq!(x, unstowed);
+    }
+    #[test]
+    fn t_with_gaps_32() {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        struct Gaps32 {
+            a: u8,
+            b: u16
+        }
+        let x = Gaps32 {
+            a: 7,
+            b: 42
+        };
+        let stowed = stow(x);
+        let unstowed = unsafe { unstow(stowed) };
+        assert_eq!(x, unstowed);
+    }
+    #[test]
+    fn t_with_gaps_64() {
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        struct Gaps64 {
+            a: u8,
+            b: u32
+        }
+        let x = Gaps64 {
+            a: 7,
+            b: 42
+        };
+        let stowed = stow(x);
+        let unstowed = unsafe { unstow(stowed) };
+        assert_eq!(x, unstowed);
+    }
+}
 
 impl<T> Drop for Stowaway<T> {
     fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::fmt;
-use core::mem::{self, size_of, MaybeUninit};
+use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::ptr;
 

--- a/test.sh
+++ b/test.sh
@@ -6,4 +6,4 @@ cargo clean
 cargo fmt -- --check
 cargo clippy -- -Dwarnings
 cargo test
-cargo miri test
+cargo +nightly miri test


### PR DESCRIPTION
Contains various tests for uninit bytes, and fixes #3. Does not fix UB when T is a ZST.